### PR TITLE
Handle regional, double fallback

### DIFF
--- a/i18n/localeSettings.js
+++ b/i18n/localeSettings.js
@@ -1,6 +1,6 @@
 
 // Best effort to gets user's preferred language translations as dictated in browser settings.
-// This implements two stage fallback to the default language resource.
+// This implements two stage fallback to the default language resource or fall through if no default.properties exists.
 // Given a region specific request, e.g. 'fr-CA', the code attempts to get the region specific properties.
 // If the region specific resource does not exist, the code falls back and attempts to get a language properties resource, e.g. 'fr'.
 // If that fails, the code falls back to the default properties resource.


### PR DESCRIPTION
Best effort to get user's preferred language translations as specified in browser language settings.
This code implements a two step, one way,  fallback using a [BCP 47 language tag](http://tools.ietf.org/html/rfc5646)  to the default language resource.
Given a region specific request, e.g. 'fr-CA', the code attempts to get the region specific properties.
If the region specific resource does not exist, the code falls back and attempts to get a language properties resource, e.g. 'fr'.
If that fails, the code falls back to the default properties resource.
In general, we should provide language keyed resources ('fr'). And only provide region or sub-tag specific resources ('fr-CA') when absolutely necessary.   And when we do provide a specific resource, we always provide the corresponding language resource.
That way if a Swiss user knows we handle French for Canada (fr-CA), he has a decent chance of handling French in general. Though not necessarily Swiss French (fr-CH).
This code does not handle a desired behavior of specific resources overriding language resources, so that an 'fr-CA' resource only needs to specify the differences between it and the base language resource. Which would result in savings from non-duplication.