### PR TITLE
Fix bug where localeData['currentLocale'] not defined

### DIFF
--- a/i18n/localeSettings.js
+++ b/i18n/localeSettings.js
@@ -67,7 +67,9 @@ xmlhttp.onreadystatechange = function() {
                     localeData['currentLocale'] = locale;
                 }
             }
-            console.log('Using localizations with locale = ' + localeData['currentLocale']);
+            if (localeData) {
+              console.log('Using localizations with locale = ' + localeData['currentLocale']);
+            }
         }
     }
 };

--- a/i18n/localeSettings.js
+++ b/i18n/localeSettings.js
@@ -49,7 +49,7 @@ xmlhttp.onreadystatechange = function() {
             }
         } else { // Successful requests
             if (locale == 'default') {
-                localeData = parseProperties(xmlhttp.responseText, {});
+                localeData = parseProperties(xmlhttp.responseText, {'currentLocale': 'default'});
                 localeData['currentLocale'] = locale;
             } else {
                 // language-region request
@@ -59,8 +59,8 @@ xmlhttp.onreadystatechange = function() {
                     scriptName = defaultScript.replace("default", localeRegion[0]);
                     xmlhttp.open("GET", scriptName, true);
                     xmlhttp.send();
-                } else {
-                    localeData = parseProperties(xmlhttp.responseText, {});
+                } else {de
+                    localeData = parseProperties(xmlhttp.responseText, {'currentLocale': locale});
                     if (regionalOverrides != "") {
                         localeData = parseProperties(regionalOverrides, localeData);
                     }

--- a/i18n/localeSettings.js
+++ b/i18n/localeSettings.js
@@ -59,7 +59,7 @@ xmlhttp.onreadystatechange = function() {
                     scriptName = defaultScript.replace("default", localeRegion[0]);
                     xmlhttp.open("GET", scriptName, true);
                     xmlhttp.send();
-                } else {de
+                } else {
                     localeData = parseProperties(xmlhttp.responseText, {'currentLocale': locale});
                     if (regionalOverrides != "") {
                         localeData = parseProperties(regionalOverrides, localeData);


### PR DESCRIPTION
````javascript
console.log('Using localizations with locale = ' + localeData['currentLocale']);
````
Was throwing an undefined error on ```` localeData['currentLocale'] ```` the first time through the code. Just needed to define it in the initializing JSON object like so: ```` {'currentLocale': locale} ````