### PR TITLE
Fixed spog-controller APM asset call

### DIFF
--- a/spog-controller.js
+++ b/spog-controller.js
@@ -37,7 +37,7 @@ class controller {
 	self.initContextBrowser = function(browser){
 		$interval.cancel(self.intervalToFetchContextBrowser);
 		//initial context call for first column
-		$http.get('contextbrowser/api/allInstances?components=BASIC&parent=null')
+		$http.get('contextbrowser/api/accessibleResources')
 	        .then(function(response){
 	            if(response.data.length>0){
 	                for(var ii=0;ii<response.data.length;ii++){


### PR DESCRIPTION
- Initial call goes to /accessibleResources instead of /allInstances. Subsequent calls with a specific parent to query will use /allInstances
- The current call to /allInstances returns all assets, and is not a secure call to make when initializing the context browser